### PR TITLE
Migrate Chart.yaml annotations to new format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
+
 ## [0.1.3] - 2023-12-20
 
 ### Changed
@@ -33,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - initial Helm Chart and repository configuration.
 
 [Unreleased]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.3...HEAD
+
+### Changed
+
+- Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
 [0.1.3]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.3...v0.1.3
 [0.1.3]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.1...v0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
+
 ## [0.1.3] - 2023-12-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
-
 ## [0.1.3] - 2023-12-20
 
 ### Changed
@@ -37,7 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - initial Helm Chart and repository configuration.
 
 [Unreleased]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.3...HEAD
-
 [0.1.3]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.3...v0.1.3
 [0.1.3]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.1...v0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.3...HEAD
 
-### Changed
-
-- Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/
 [0.1.3]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.3...v0.1.3
 [0.1.3]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/giantswarm/gitops-server-app/compare/v0.1.1...v0.1.2

--- a/helm/gitops-server/Chart.yaml
+++ b/helm/gitops-server/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
 name: gitops-server
 home: https://github.com/giantswarm/gitops-server-app
-description: Weave Gitops is a set of tools and services to aid your interactions with Flux
+description: Weave Gitops is a set of tools and services to aid your interactions
+  with Flux
 icon: https://s.giantswarm.io/app-icons/weaveworks/1/icon_light.svg
 keywords:
-  - gitops
-  - flux
+- gitops
+- flux
 type: application
 version: 0.1.3
-appVersion: "v0.18.0"
+appVersion: v0.18.0
 annotations:
-  application.giantswarm.io/team: honeybadger
-  config.giantswarm.io/version: 1.x.x
+  io.giantswarm.application.team: honeybadger

--- a/helm/gitops-server/templates/_helpers.tpl
+++ b/helm/gitops-server/templates/_helpers.tpl
@@ -39,7 +39,7 @@ helm.sh/chart: {{ include "chart.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 


### PR DESCRIPTION
This PR migrates the Chart.yaml metadata to use Giant Swarm's new annotation format.

Changes:
- Set apiVersion to v2
- Convert `restrictions` field to annotations with new keys (io.giantswarm.application.restrictions.*)
- Migrate annotation keys to new format (io.giantswarm.application.*)
- Remove deprecated `config.giantswarm.io/version` annotation
- Update template files to use new annotation keys
- Update architect-orb to version 6.10.0 or higher

Reference: https://docs.giantswarm.io/reference/platform-api/chart-metadata/