### PR TITLE
feat(helm): add Gateway API route support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Gateway API route support as an alternative to Ingress for clusters using Gateway API.
+  - Support for HTTPRoute, GRPCRoute, TCPRoute, TLSRoute, and UDPRoute kinds.
+  - Envoy Gateway SecurityPolicy integration with basic auth, CORS, JWT, OIDC, external auth, and authorization.
+
 ### Changed
 
 - Migrate Chart.yaml annotations to new format as per https://docs.giantswarm.io/reference/platform-api/chart-metadata/

--- a/helm/gitops-server/templates/route.yaml
+++ b/helm/gitops-server/templates/route.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.route.enabled -}}
+{{- $route := .Values.route }}
+{{- $fullName := include "chart.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: {{ $route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ $route.name | default $fullName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    {{- with $route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if $route.additionalRules }}
+    {{- tpl (toYaml $route.additionalRules) $ | nindent 4 }}
+    {{- end }}
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+      {{- with $route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- if and $route.securityPolicy $route.securityPolicy.enabled }}
+{{- $policy := $route.securityPolicy }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ $route.name | default $fullName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "chart.labels" $ | nindent 4 }}
+    {{- with $policy.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with $policy.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: {{ $route.kind | default "HTTPRoute" }}
+      name: {{ $route.name | default $fullName }}
+  {{- with $policy.basicAuth }}
+  basicAuth:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $policy.cors }}
+  cors:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $policy.jwt }}
+  jwt:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $policy.oidc }}
+  oidc:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $policy.extAuth }}
+  extAuth:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $policy.authorization }}
+  authorization:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+

--- a/helm/gitops-server/values.schema.json
+++ b/helm/gitops-server/values.schema.json
@@ -492,6 +492,103 @@
         },
         "tolerations": {
             "type": "array"
+        },
+        "route": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": ["GRPCRoute", "HTTPRoute", "TCPRoute", "TLSRoute", "UDPRoute"]
+                },
+                "name": {
+                    "type": "string"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "hostnames": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "parentRefs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "namespace": {
+                                "type": "string"
+                            },
+                            "sectionName": {
+                                "type": "string"
+                            },
+                            "port": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                },
+                "matches": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "filters": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "additionalRules": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "securityPolicy": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "annotations": {
+                            "type": "object"
+                        },
+                        "labels": {
+                            "type": "object"
+                        },
+                        "basicAuth": {
+                            "type": "object"
+                        },
+                        "cors": {
+                            "type": "object"
+                        },
+                        "jwt": {
+                            "type": "object"
+                        },
+                        "oidc": {
+                            "type": "object"
+                        },
+                        "extAuth": {
+                            "type": "object"
+                        },
+                        "authorization": {
+                            "type": "object"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/helm/gitops-server/values.yaml
+++ b/helm/gitops-server/values.yaml
@@ -143,6 +143,73 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+# -- Gateway API route configuration
+# This is an alternative to ingress for clusters using Gateway API
+route:
+  # -- Enable the Gateway API route
+  enabled: false
+  # -- Set the route kind
+  # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
+  kind: HTTPRoute
+  # -- Override the route name (defaults to chart fullname)
+  name: ""
+  # -- Annotations to add to the route
+  annotations: {}
+  # -- Labels to add to the route
+  labels: {}
+  # -- Hostnames that the route should match
+  hostnames: []
+  # - gitops.example.com
+  # -- Parent references (Gateway) that the route should attach to
+  parentRefs: []
+  # - name: my-gateway
+  #   namespace: gateway-system
+  # -- Matches define conditions used for matching the rule against incoming requests
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+  # -- Filters define the filters that are applied to requests that match this rule
+  filters: []
+  # -- Additional custom rules that can be added to the route
+  additionalRules: []
+  # -- Envoy Gateway SecurityPolicy configuration
+  securityPolicy:
+    # -- Enable the SecurityPolicy resource
+    enabled: false
+    # -- Annotations to add to the SecurityPolicy
+    annotations: {}
+    # -- Labels to add to the SecurityPolicy
+    labels: {}
+    # -- Basic authentication configuration
+    # basicAuth:
+    #   users:
+    #     name: <secret_name>
+    # -- CORS configuration
+    # cors:
+    #   allowOrigins:
+    #     - "*"
+    # -- JWT authentication configuration
+    # jwt:
+    #   providers:
+    #     - name: my-provider
+    #       issuer: https://issuer.example.com
+    # -- OIDC authentication configuration
+    # oidc:
+    #   provider:
+    #     issuer: https://issuer.example.com
+    # -- External authentication configuration
+    # extAuth:
+    #   http:
+    #     backendRef:
+    #       name: auth-service
+    #       port: 80
+    # -- Authorization rules
+    # authorization:
+    #   defaultAction: Deny
+    #   rules: []
+
 extraVolumes: []
 extraVolumeMounts: []
 # Example using extraVolumes and extraVolumeMounts to load 'oidc-auth' secret


### PR DESCRIPTION
Add Gateway API HTTPRoute and SecurityPolicy support as an alternative to traditional Ingress for clusters using Gateway API.

Features:
- HTTPRoute, GRPCRoute, TCPRoute, TLSRoute, UDPRoute support
- Envoy Gateway SecurityPolicy integration with:
  - Basic authentication
  - CORS configuration
  - JWT authentication
  - OIDC authentication
  - External authentication
  - Authorization rules
- Additional custom rules support
- Configurable filters and matches
- Update Changelog